### PR TITLE
Fix XGB inference inside Agents

### DIFF
--- a/giza/agents/agent.py
+++ b/giza/agents/agent.py
@@ -252,6 +252,7 @@ class GizaAgent(GizaModel):
         custom_output_dtype: Optional[str] = None,
         job_size: str = "M",
         dry_run: bool = False,
+        model_category: Optional[str] = None,
         **result_kwargs: Any,
     ) -> Optional[Union[Tuple[Any, Any], "AgentResult"]]:
         """
@@ -270,6 +271,7 @@ class GizaAgent(GizaModel):
             custom_output_dtype=custom_output_dtype,
             job_size=job_size,
             dry_run=dry_run,
+            model_category=model_category,
         )
 
         self.verifiable = verifiable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "giza-agents"
-version = "0.4.0"
+version = "0.4.1"
 
 description = "A Python SDK for Giza platform"
 authors = [


### PR DESCRIPTION
For doing XGBoost inference in the Agents the parameter `model_category` is needed. It was missing inside the `predict` function preventing from doing verifiable inferences in the Agent