### PR TITLE
Fix output dtype in giza model

### DIFF
--- a/giza/agents/model.py
+++ b/giza/agents/model.py
@@ -267,7 +267,7 @@ class GizaModel:
         Raises:
             ValueError: If required parameters are not provided or the session is not initialized.
         """
-        output_dtype = "default_dtype"  # Define a default or determine a better initial value based on context
+        output_dtype = "Tensor<FP16x16>"
         try:
             logger.info("Predicting")
             if verifiable:

--- a/giza/agents/model.py
+++ b/giza/agents/model.py
@@ -267,6 +267,7 @@ class GizaModel:
         Raises:
             ValueError: If required parameters are not provided or the session is not initialized.
         """
+        output_dtype = "default_dtype"  # Define a default or determine a better initial value based on context
         try:
             logger.info("Predicting")
             if verifiable:


### PR DESCRIPTION
Fix `UnboundLocalError: cannot access local variable 'output_dtype'` by initializing `output_dtype`