### PR TITLE
fix: Session is not initialized.

### DIFF
--- a/giza/agents/model.py
+++ b/giza/agents/model.py
@@ -92,6 +92,7 @@ class GizaModel:
             self.framework = self.version.framework
             self.uri = self._retrieve_uri()
             self.endpoint_id = self._get_endpoint_id()
+            self._cache = Cache(os.path.join(os.getcwd(), "tmp", "cachedir"))
             if output_path is not None:
                 self._output_path = output_path
             else:
@@ -99,7 +100,6 @@ class GizaModel:
                     tempfile.gettempdir(),
                     f"{self.model_id}_{self.version_id}_{self.model.name}",
                 )
-            self._cache = Cache(os.path.join(os.getcwd(), "tmp", "cachedir"))
             self.session = self._set_session()
             self._download_model()
 

--- a/giza/agents/model.py
+++ b/giza/agents/model.py
@@ -92,8 +92,6 @@ class GizaModel:
             self.framework = self.version.framework
             self.uri = self._retrieve_uri()
             self.endpoint_id = self._get_endpoint_id()
-            self._cache = Cache(os.path.join(os.getcwd(), "tmp", "cachedir"))
-            self.session = self._set_session()
             if output_path is not None:
                 self._output_path = output_path
             else:
@@ -101,6 +99,8 @@ class GizaModel:
                     tempfile.gettempdir(),
                     f"{self.model_id}_{self.version_id}_{self.model.name}",
                 )
+            self._cache = Cache(os.path.join(os.getcwd(), "tmp", "cachedir"))
+            self.session = self._set_session()
             self._download_model()
 
     def _get_endpoint_id(self) -> int:


### PR DESCRIPTION
When using GizaModel with `id` and `version`, it tries to set the session after downloading the model but since the `_output_path` is not set it is unable to download the model and initialize the session.

Tested with
```
m = GizaModel(id=766, version=1)
m.predict(X)
```