### PR TITLE
change actions/checkout to v4,  python to v5, add bandit for common s…

### DIFF
--- a/.github/workflows/onpush.yml
+++ b/.github/workflows/onpush.yml
@@ -1,36 +1,50 @@
 name: Giza CI
 
 on:
-    pull_request:
-      types: [ opened, synchronize ]
-    push:
-      branches: [main]
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     strategy:
       matrix:
         python-version: ["3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
           poetry config virtualenvs.create false
           poetry install --all-extras
+          
+      - name: Perform Bandit Analysis
+        uses: PyCQA/bandit-action@v1
+        with:
+          severity: high, medium
+          confidence: high
+          targets: "."
+
       - name: Lint with ruff
         run: |
           poetry run ruff giza
+          
       - name: Pre-commit check
         run: |
           poetry run pre-commit run --all-files
+          
       - name: Testing
         run: |
           poetry run pytest --cov=giza.agents --cov-report term-missing

--- a/.github/workflows/onrelease.yml
+++ b/.github/workflows/onrelease.yml
@@ -28,11 +28,13 @@ jobs:
             python -m pip install poetry
             poetry config virtualenvs.create false
             poetry install
+
       - name: Lint with ruff
         run: |
             poetry run ruff giza
       - name: Build dist
         run: poetry build
+        
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Changes made

-Changed `actions/checkout` from v3 to v4 to make sure the environment is kept on date
-Changed `actions/setup-python` from v4 to v5 to make sure the environment is kept on date
-Gave one more line each to make sure the pipeline lines on CI are more readable

Additions

-Added Bandit for GitHub Actions to find common security issues in Python code before it finds production, currently learning the tool and will try to figure out how I can fail if certain levels of security vulnerabilities (ie. high) are found.

Future plans

-Adding Safety for vulnerability scanning in packages, however, depending on the plan used, it can go up to $30 per month per developer
-Encompassing Bandit scan to stop the ci as soon as a certain level and certain confidence for vulnerability is found (such as high vulnerability high confidence).